### PR TITLE
Outline: only match nodes that are immediate siblings

### DIFF
--- a/languages/gdscript/outline.scm
+++ b/languages/gdscript/outline.scm
@@ -19,6 +19,7 @@
 ; annotated variables from regular variables
 (_
   (annotation) @context
+  .
   (variable_statement
     "var" @context
     name: (_) @name


### PR DESCRIPTION
This prevents `@tool` to be matched against every variable in a script.

Fixes #23