### PR TITLE
feat: add `gdshader` syntax highlighting

### DIFF
--- a/data/shader_test.gdshader
+++ b/data/shader_test.gdshader
@@ -1,0 +1,9 @@
+shader_type canvas_item;
+
+uniform float blur_amount: hint_range(0.0, 10.0) = 0.0;
+uniform sampler2D SCREEN_TEXTURE: hint_screen_texture, filter_linear_mipmap;
+
+void fragment() {
+	vec4 blurred = texture(SCREEN_TEXTURE, SCREEN_UV, blur_amount);
+	COLOR = vec4(blurred.rgb, 1.0);
+}

--- a/extension.toml
+++ b/extension.toml
@@ -22,3 +22,7 @@ commit = "1f1e782fe2600f50ae57b53876505b8282388d77"
 [grammars.godot_resource]
 repository = "https://github.com/PrestonKnopp/tree-sitter-godot-resource"
 commit = "2ffb90de47417018651fc3b970e5f6b67214dc9d"
+
+[grammars.gdshader]
+repository = "https://github.com/GodOfAvacyn/tree-sitter-gdshader"
+commit = "ffd9f958df13cae04593781d7d2562295a872455"

--- a/languages/gdshader/config.toml
+++ b/languages/gdshader/config.toml
@@ -1,0 +1,10 @@
+name = "GDShader"
+grammar = "gdshader"
+path_suffixes = ["gdshader"]
+line_comments = ["// "]
+block_comment = ["/* ", " */"]
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+]

--- a/languages/gdshader/highlights.scm
+++ b/languages/gdshader/highlights.scm
@@ -1,0 +1,135 @@
+; Made using highlights done for nvim-treesitter as a base
+; https://github.com/nvim-treesitter/nvim-treesitter/blob/42fc28ba918343ebfd5565147a42a26580579482/queries/gdshader/highlights.scm
+
+; Keywords
+[
+  "render_mode"
+  "shader_type"
+  "group_uniforms"
+  "global"
+  "instance"
+  "const"
+  "varying"
+  "uniform"
+  ; type
+  "struct"
+  ; modifiers
+  "in"
+  "out"
+  "inout"
+  (precision_qualifier)
+  (interpolation_qualifier)
+  ; repeat
+  "while"
+  "for"
+  ; return
+  "continue"
+  "break"
+  "return"
+  ; conditional
+  "if"
+  "else"
+  "switch"
+  "case"
+  "default"
+  ; directive
+  "#"
+  "include"
+] @keyword
+
+[
+  "="
+  "+="
+  "-="
+  "!"
+  "~"
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "||"
+  "&&"
+  "|"
+  "^"
+  "&"
+  "=="
+  "!="
+  ">"
+  ">="
+  "<="
+  "<"
+  "<<"
+  ">>"
+  "++"
+  "--"
+] @operator
+
+; Types
+(boolean) @boolean
+[
+  (integer)
+  (float)
+] @number
+(string) @string
+
+; Delimiters
+[
+  "."
+  ","
+  ";"
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  (builtin_type)
+  (ident_type)
+] @type
+
+[
+  (shader_type)
+  (render_mode)
+  (hint_name)
+] @attribute
+
+(builtin_variable) @constant
+
+(builtin_function) @function
+
+(group_uniforms_declaration
+  group_name: (ident) @property
+  subgroup_name: (ident) @property)
+
+(struct_declaration
+  name: (ident) @type)
+
+(struct_member
+  name: (ident) @property)
+
+(function_declaration
+  name: (ident) @function)
+
+(parameter
+  name: (ident) @variable.special)
+
+(member_expr
+  member: (ident) @property)
+
+(call_expr
+  function: [
+    (ident)
+    (builtin_type)
+  ] @function)
+
+(call_expr
+  function: (builtin_type) @function)
+
+(comment) @comment

--- a/languages/gdshader/injections.scm
+++ b/languages/gdshader/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+  (#set! injection.language "comment"))

--- a/languages/gdshader/outline.scm
+++ b/languages/gdshader/outline.scm
@@ -1,0 +1,4 @@
+(source_file
+    (function_declaration
+        name: (_) @name) @item
+)

--- a/languages/gdshader/textobjects.scm
+++ b/languages/gdshader/textobjects.scm
@@ -1,0 +1,2 @@
+(function_declaration
+  (block) @function.inside) @function.around


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable):

On one of the three machines on which I tested this change, one had a tough time buidling the extension. `clang` was being killed while building the parser for `gdshader`.

> [!NOTE]
> On Linux, you can keep track of the build progress by checking the log file under `~/.local/share/zed/logs/Zed.log`


**What kind of change does this PR introduce?**

Syntax highlighting for `.gdshader` files.

**Does this PR introduce a breaking change?**

No

## New feature or change ##


**What is the current behavior?** 

No highlighting for `.gdshader`.

**What is the new behavior?**

Introduces it, using parser from [GodOfAvacyn/tree-sitter-gdshader](https://github.com/GodOfAvacyn/tree-sitter-gdshader)
