### PR TITLE
Configure hard tabs and add a note about using gdformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,23 @@ You can change these settings in Godot by going to *Editor > Editor Settings > N
 }
 ```
 
+Optionally, if you have [`godot-gdscript-toolkit`](https://github.com/Scony/godot-gdscript-toolkit) installed, you can use `gdformat` to format GDScript files:
+
+```json
+{
+  "languages": {
+    "GDScript": {
+      "formatter": {
+        "external": {
+          "command": "gdformat",
+          "arguments": ["-"]
+        }
+      }
+    }
+  }
+}
+```
+
 ## Contributing
 
 ## Editing .scm files

--- a/languages/gdscript/config.toml
+++ b/languages/gdscript/config.toml
@@ -12,3 +12,4 @@ brackets = [
 auto_indent_using_last_non_empty_line = false
 increase_indent_pattern = ":\\s*$"
 autoclose_before = ":.,}])>"
+hard_tabs = true


### PR DESCRIPTION
This makes it so that you don't have to manually configure `hard_tabs` for GDScript.

I also added a node about using `gdformat` since it took me a minute to figure that out (and it's mentioned in a few issues in this repo)