### PR TITLE
Highlight when as a control-flow keyword

### DIFF
--- a/languages/gdscript/highlights.scm
+++ b/languages/gdscript/highlights.scm
@@ -191,6 +191,7 @@
   "else"
   "elif"
   "match"
+  "when"
   "while"
   "for"
   "return"
@@ -199,7 +200,7 @@
   "await"
   "pass"
   (breakpoint_statement)
-] @keyword.control
+] @keyword @keyword.control
 
 ; Operator
 [


### PR DESCRIPTION
Fix #93 
`when` is now highlighted as a control-flow keyword.
Themes without a `keyword.control` style fall back to the regular `keyword` style.
